### PR TITLE
docs: add initial README for project context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Jenkins GitOps
+
+A GitOps-driven setup for deploying Jenkins on Kubernetes.
+
+> 🚧 This repository is currently a proof-of-concept (POC) for a declarative Jenkins deployment.
+
+## Status
+
+This project is in early development. Structure and tooling may evolve.


### PR DESCRIPTION
Provides minimal context for this GitOps-based Jenkins deployment. Marks the project as a POC and sets expectations for future structure and tooling.