### PR TITLE
chore: rename workflow to helm-validate

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -1,5 +1,5 @@
 ---
-name: Validate Helm Charts and Values (all environments)
+name: Validate Helm Charts and Values
 
 "on":
   push:


### PR DESCRIPTION
Renames the GHA workflow to accurately reflect that it validates both the Helm chart structure and values files.