### PR TITLE
feat(init): add InitContainer and controller template

### DIFF
--- a/base/jenkins/templates/controller.yaml
+++ b/base/jenkins/templates/controller.yaml
@@ -1,0 +1,38 @@
+---
+# Minimal Deployment template for Jenkins controller with InitContainer support
+# Renders from environments/dev/values.yaml or equivalent in staging/prod
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+  labels:
+    app: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+{{- with .Values.controller.initContainers }}
+      initContainers:
+{{ toYaml . | indent 8 }}
+{{- end }}
+
+      containers:
+        - name: jenkins
+          image: jenkins/jenkins:lts
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: jcasc
+              mountPath: /var/jenkins_home/casc_configs
+
+{{- with .Values.controller.volumes }}
+      volumes:
+{{ toYaml . | indent 6 }}
+{{- end }}

--- a/environments/dev/values.yaml
+++ b/environments/dev/values.yaml
@@ -1,7 +1,6 @@
 ---
-# Helm values for Jenkins in the dev environment
-# Enables JCasC, disables the default config, and prepares for external config
-# injection.
+# Helm values for Jenkins in the dev environment (local k3d cluster)
+# This file enables JCasC, disables the default config, and prepares for external config injection.
 
 # The 'controller' section configures the Jenkins controller behavior
 controller:
@@ -12,7 +11,6 @@ controller:
 
   # Jenkins Configuration as Code (JCasC) settings
   JCasC:
-
     # Enable JCasC support in the Helm chart
     enabled: true
 
@@ -22,3 +20,17 @@ controller:
     # Placeholder for inline config scripts.
     # We rely on mounted files via InitContainer instead.
     configScripts: {}
+
+  # Define shared volumes for InitContainer and Jenkins controller
+  volumes:
+    - name: jcasc
+      emptyDir: {}
+
+  # InitContainer to copy JCasC files into a shared volume
+  initContainers:
+    - name: jcasc-init
+      image: alpine:3.18
+      command: ["/entrypoint.sh"]
+      volumeMounts:
+        - name: jcasc
+          mountPath: /workspace/jcasc


### PR DESCRIPTION
Adds a basic InitContainer setup and minimal controller deployment template for running Jenkins locally. Supports injecting JCasC config via shared volume mounts.