### PR TITLE
chore: update lint config and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmpcharts/
 *.log
 *.out
 *.pid
+rendered.*
 
 # Editor and system files
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-yaml
+        exclude: ^base/jenkins/templates/.*
       - id: check-added-large-files
 
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.32.0
     hooks:
       - id: yamllint
+        exclude: ^base/jenkins/templates/.*
 
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1


### PR DESCRIPTION
Excludes Helm template files from yamllint and check-yaml to prevent false errors. Adds rendered.* to .gitignore.