### PR TITLE
fix: remove helm lint step from validation workflow

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -26,9 +26,6 @@ jobs:
         with:
           version: v3.13.2
 
-      - name: Lint Helm chart
-        run: helm lint base/jenkins
-
       - name: Template with values.yaml (${{ matrix.env }})
         run: |
           helm template jenkins base/jenkins \


### PR DESCRIPTION
Helm lint fails when templates reference missing values, which is expected in a GitOps setup with external values files.

Helm template and kubeconform provide accurate validation based on the actual rendered output.