### PR TITLE
fix: export Jenkins on port 8080

### DIFF
--- a/apps/dev/service.yaml
+++ b/apps/dev/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins
+  namespace: dev
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jenkins
+  type: LoadBalancer


### PR DESCRIPTION
Created a service.yaml file to expose Jenkins on port 8080.