### PR TITLE
feat: Add initial Helm templates for sidecar model

### DIFF
--- a/base/jenkins/templates/_helpers.tpl
+++ b/base/jenkins/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{- define "jenkins.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "jenkins.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "jenkins.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "jenkins.labels" -}}
+helm.sh/chart: {{ include "jenkins.chart" . }}
+{{ include "jenkins.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "jenkins.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jenkins.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "jenkins.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "jenkins.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/base/jenkins/templates/deployment.yaml
+++ b/base/jenkins/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "jenkins.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jenkins.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "jenkins.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 60
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: jenkins-home
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "jenkins.fullname" . }}-home
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        - name: jcasc-config
+          emptyDir: {}
+        - name: scripts
+          emptyDir: {}
+      containers:
+        - name: jenkins
+          image: "{{ .Values.jenkinsImage }}"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: agent
+              containerPort: 50000
+              protocol: TCP
+          volumeMounts:
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+            - name: jcasc-config
+              mountPath: /var/jenkins_home/casc.d
+        - name: jcasc-sidecar
+          image: "{{ .Values.sidecarImage }}"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              echo "Sidecar started. Implement script cloning, cron, and reload logic here.";
+              sleep infinity;
+          volumeMounts:
+            - name: jcasc-config
+              mountPath: /var/jenkins_home/casc.d
+            - name: scripts
+              mountPath: /scripts

--- a/base/jenkins/templates/pvc.yaml
+++ b/base/jenkins/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jenkins.fullname" . }}-home
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/base/jenkins/templates/service.yaml
+++ b/base/jenkins/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jenkins.fullname" . }}
+  labels:
+    {{- include "jenkins.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+    - port: 50000
+      targetPort: 50000
+      protocol: TCP
+      name: agent
+  selector:
+    {{- include "jenkins.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Add basic Kubernetes templates for the Jenkins chart.

Includes templates for:
- PersistentVolumeClaim (PVC) for Jenkins home
- Service for cluster access
- Deployment with Jenkins and placeholder sidecar containers
- Standard Helm helpers