### PR TITLE
feat: Add ArgoCD AppProject for Jenkins

### DIFF
--- a/argocd-apps/jenkins-dev-app.yaml
+++ b/argocd-apps/jenkins-dev-app.yaml
@@ -4,7 +4,7 @@ metadata:
   name: jenkins-dev
   namespace: argocd
 spec:
-  project: default
+  project: jenkins
   source:
     repoURL: https://github.com/lfit/jenkins-gitops
     targetRevision: master

--- a/argocd-apps/jenkins-project.yaml
+++ b/argocd-apps/jenkins-project.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: jenkins
+  namespace: argocd
+spec:
+  description: Jenkins Project
+  sourceRepos:
+  - https://github.com/lfit/jenkins-gitops
+  - https://github.com/lfit/ciman-gitops
+  - https://github.com/lfit/releng-global-jjb
+  destinations:
+  - namespace: jenkins-dev
+    server: https://kubernetes.default.svc
+  - namespace: jenkins-staging
+    server: '*'
+  - namespace: jenkins-prod
+    server: '*'
+  clusterResourceWhitelist:
+  - group: ''
+    kind: Namespace
+  namespaceResourceWhitelist:
+  - group: '*'
+    kind: '*'


### PR DESCRIPTION
Define the 'jenkins' AppProject resource in ArgoCD. Update jenkins-dev application to use this project. This project will manage permissions and scope for all Jenkins-related ArgoCD applications (dev, staging, prod).