### PR TITLE
fix: restructure workflow architecture

### DIFF
--- a/.github/workflows/build-jenkins-image.yml
+++ b/.github/workflows/build-jenkins-image.yml
@@ -1,88 +1,63 @@
-name: Build and Test Jenkins Image
+name: Build and Push Jenkins Image
 
 on:
   workflow_run:
-    workflows: ["Build and Test Jenkins Image"]
+    workflows: ["Validate Dockerfile"]
     types:
       - completed
     branches:
       - main
 
 jobs:
-  update-staging-image:
+  build-and-push:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get latest image tag
-        id: get-tag
+      - name: Determine registry and environment
+        id: registry
         run: |
-          LATEST_TAG="main-$(echo ${{ github.sha }} | cut -c1-7)"
-          echo "image-tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
-          echo "Found new image tag: ${LATEST_TAG}"
-
-      - name: Update staging values.yaml
-        id: update-values
-        run: |
-          echo "Updating staging/values.yaml with new image tag..."
-
-          sed -i 's|repository: "jenkins/jenkins"|repository: "ghcr.io/vvalderrv/jenkins"|g' staging/values.yaml
-          sed -i 's|tag: "lts-jdk17"|tag: "${{ steps.get-tag.outputs.image-tag }}"|g' staging/values.yaml
-
-          if git diff --quiet staging/values.yaml; then
-            echo "No changes needed in staging/values.yaml"
-            echo "changes-made=false" >> $GITHUB_OUTPUT
+          if [[ "${{ github.repository }}" == "lfit/jenkins-gitops" ]]; then
+            # Upstream repository - production registry
+            REGISTRY="ghcr.io/lfit/jenkins"
+            ENVIRONMENT="production"
           else
-            echo "Changes made to staging/values.yaml:"
-            git diff staging/values.yaml
-            echo "changes-made=true" >> $GITHUB_OUTPUT
+            # Fork repository - development registry
+            REGISTRY="ghcr.io/${{ github.repository_owner }}/jenkins"
+            ENVIRONMENT="development"
           fi
 
-      - name: Create Pull Request for staging update
-        if: steps.update-values.outputs.changes-made == 'true'
-        uses: peter-evans/create-pull-request@v5
+          TAG="main-$(echo ${{ github.sha }} | cut -c1-7)"
+          echo "registry=$REGISTRY" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          echo "image-tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Using registry: $REGISTRY for $ENVIRONMENT environment"
+
+      - name: Build and push Jenkins image
+        uses: docker/build-push-action@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: |
-            Chore: Update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}
-
-            - Updates staging/values.yaml with new image tag
-            - Triggered by successful image build: ${{ github.sha }}
-            - Image: ghcr.io/vvalderrv/jenkins:${{ steps.get-tag.outputs.image-tag }}
-          title: "Chore: Update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}"
-          body: |
-            ## Staging Image Update
-
-            This PR automatically updates the Jenkins staging environment with a newly built and tested image.
-
-            **Changes:**
-            - New Image Tag: ${{ steps.get-tag.outputs.image-tag }}
-            - Repository: ghcr.io/vvalderrv/jenkins
-            - Build Status: All tests passed
-            - Triggered by: ${{ github.event.workflow_run.html_url }}
-
-            **What happens after merge:**
-            1. ArgoCD will detect the changes in staging/values.yaml
-            2. Jenkins staging environment will automatically update
-            3. New image will be deployed with all tested plugins and tools
-
-            This PR was automatically created by the Update Staging Image workflow.
-          branch: update-staging-image-${{ steps.get-tag.outputs.image-tag }}
-          delete-branch: true
-
-      - name: Output update status
-        run: |
-          if [ "${{ steps.update-values.outputs.changes-made }}" == "true" ]; then
-            echo "Staging image update PR created successfully"
-          else
-            echo "No staging update needed - image already current"
-          fi
+          context: ./build
+          push: true
+          tags: |
+            ${{ steps.registry.outputs.registry }}:${{ steps.registry.outputs.image-tag }}
+            ${{ steps.registry.outputs.registry }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            environment=${{ steps.registry.outputs.environment }}

--- a/.github/workflows/deploy-staging-environment.yml
+++ b/.github/workflows/deploy-staging-environment.yml
@@ -1,8 +1,8 @@
-name: Update Staging Image
+name: Deploy Staging Environment
 
 on:
   workflow_run:
-    workflows: ["Build and Test Jenkins Image"]
+    workflows: ["Build and Push Jenkins Image"]
     types:
       - completed
     branches:
@@ -12,6 +12,9 @@ jobs:
   update-staging:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -20,48 +23,44 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Get image tag from triggering workflow
+      - name: Get image tag from build workflow
         id: get-tag
         run: |
-          # Get the SHA that triggered the workflow
+          # Get the SHA that triggered the build workflow
           TRIGGER_SHA="${{ github.event.workflow_run.head_sha }}"
-          echo "Triggered by SHA: $TRIGGER_SHA"
-
-          # Create image tag from branch and short SHA
-          BRANCH_NAME="${{ github.event.workflow_run.head_branch }}"
           SHORT_SHA=$(echo "$TRIGGER_SHA" | cut -c1-7)
-          IMAGE_TAG="${BRANCH_NAME}-${SHORT_SHA}"
+          IMAGE_TAG="main-${SHORT_SHA}"
 
           echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          echo "Generated image tag: $IMAGE_TAG"
+          echo "Generated staging image tag: $IMAGE_TAG"
 
       - name: Update staging values
         run: |
           echo "Updating staging/values.yaml with new image tag: ${{ steps.get-tag.outputs.image-tag }}"
 
+          # Determine registry based on repository
+          if [[ "${{ github.repository }}" == "lfit/jenkins-gitops" ]]; then
+            REGISTRY="ghcr.io/lfit/jenkins"
+          else
+            REGISTRY="ghcr.io/${{ github.repository_owner }}/jenkins"
+          fi
+
           # Update the repository and tag in staging values
-          sed -i 's|repository: "jenkins/jenkins"|repository: "ghcr.io/vvalderrv/jenkins"|g' staging/values.yaml
-          sed -i 's|tag: "lts-jdk17"|tag: "${{ steps.get-tag.outputs.image-tag }}"|g' staging/values.yaml
+          sed -i "s|repository: \".*\"|repository: \"$REGISTRY\"|g" staging/values.yaml
+          sed -i "s|tag: \".*\"|tag: \"${{ steps.get-tag.outputs.image-tag }}\"|g" staging/values.yaml
 
           echo "Updated staging/values.yaml:"
           cat staging/values.yaml
-
-      - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: |
-            Chore: Update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}
-
-            Triggered by successful image build: ${{ github.event.workflow_run.head_sha }}
-          file_pattern: staging/values.yaml
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
-            Chore: Update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}
-          title: "Chore: Update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}"
+            chore: update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}
+
+            Triggered by successful image build: ${{ github.event.workflow_run.head_sha }}
+          title: "chore: update staging Jenkins image to ${{ steps.get-tag.outputs.image-tag }}"
           body: |
             ## Automated staging image update
 


### PR DESCRIPTION
- Replace broken build-jenkins-image.yml with Docker build & push workflow
- Rename update-staging-image.yml to deploy-staging-environment.yml
- Remove circular dependencies and implement proper trigger chain
- Add environment-aware registry selection (dev vs prod registries)