### PR TITLE
feat: expose Jenkins staging with public ingress

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -9,6 +9,20 @@ controller:
     tag: "latest"
     pullPolicy: "IfNotPresent"
 
+  # Add ingress configuration for public access
+  ingress:
+    enabled: true
+    apiVersion: networking.k8s.io/v1
+    ingressClassName: nginx
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt
+    hostName: jenkins-stag.opensearch.cluster.linuxfound.info
+    path: /
+    tls:
+      - secretName: jenkins-staging-tls
+        hosts:
+          - jenkins-stag.opensearch.cluster.linuxfound.info
+
 # Defining resource requests and limits for the staging environment.
 resources:
   requests:


### PR DESCRIPTION
## Summary
Adds public ingress configuration to expose Jenkins staging environment with HTTPS.

## Changes
- Configure ingress for jenkins-stag.opensearch.cluster.linuxfound.info
- Enable Let's Encrypt SSL certificates
- Use nginx ingress controller with external DNS

## Result
Jenkins staging will be accessible at: https://jenkins-stag.opensearch.cluster.linuxfound.info/