### PR TITLE
fix: add OIDC authentication to ArgoCD workflow

### DIFF
--- a/.github/workflows/deploy-argocd-apps.yaml
+++ b/.github/workflows/deploy-argocd-apps.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::156041419073:role/terraform-deploy-oidc
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/terraform-deploy-oidc
           aws-region: us-west-2
 
       - name: Install kubectl

--- a/.github/workflows/deploy-argocd-apps.yaml
+++ b/.github/workflows/deploy-argocd-apps.yaml
@@ -14,9 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::156041419073:role/terraform-deploy-oidc
+          aws-region: us-west-2
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v3


### PR DESCRIPTION
- Add id-token write permission for OIDC authentication
- Configure AWS credentials using terraform-deploy-oidc role
- Use AWS_ACCOUNT_ID variable for cross-project reusability