### PR TITLE
fix: resolve jcasc ConfiguratorConflictException

### DIFF
--- a/base/jenkins/jcasc_yamls/00-main.yaml
+++ b/base/jenkins/jcasc_yamls/00-main.yaml
@@ -8,7 +8,6 @@ jenkins:
   views:
     - all:
         name: "all"
-  mode: EXCLUSIVE
   labelString: "${JCASC_MASTER_LABELS}"
   projectNamingStrategy: "standard"
   # resourceRootURL: "${JCASC_RESOURCE_ROOT_URL}"

--- a/base/jenkins/values.yaml
+++ b/base/jenkins/values.yaml
@@ -20,6 +20,8 @@ jenkins:
       tag: "latest"
       pullPolicy: "IfNotPresent"
 
+    executorMode: EXCLUSIVE
+
     JCasC:
       defaultConfig: true
       configScripts:
@@ -33,7 +35,6 @@ jenkins:
             views:
               - all:
                   name: "all"
-            mode: EXCLUSIVE
             labelString: "${JCASC_MASTER_LABELS}"
             projectNamingStrategy: "standard"
             noUsageStatistics: true


### PR DESCRIPTION
- Add controller.executorMode: EXCLUSIVE to chart values
- Remove mode: EXCLUSIVE from JCasC configScript in values.yaml
- Remove mode: EXCLUSIVE from base/jenkins/jcasc_yamls/00-main.yaml
- Keep defaultConfig: true for essential Kubernetes cloud setup