### PR TITLE
fix: restore 02-security via sidecar

### DIFF
--- a/base/jenkins/values.yaml
+++ b/base/jenkins/values.yaml
@@ -62,6 +62,18 @@ jenkins:
                 - key: "SILO"
                   value: '${JCASC_JENKINSGLOBALENVVARS_SILO}'
 
+        02-security: |
+          jenkins:
+            securityRealm:
+              local:
+                allowsSignup: false
+                users:
+                  - id: "admin"
+                    password: '${JCASC_JENKINSSECURITY_ADMINPASSWORD}'
+            authorizationStrategy:
+              loggedInUsersCanDoAnything:
+                allowAnonymousRead: false
+
         03-tools: |
           tool:
             jdk:


### PR DESCRIPTION
- Added 02-security back to configScripts in values.yaml
- Removed volume mounting approach that caused conflicts
- Uses existing sidecar system for automatic loading
- All 7 JCasC configurations now properly configured
- Security realm and authorization strategy restored
- Validates: helm lint, kubeconform, JCasC flow verified