### PR TITLE
feat: Add Jenkins admin users via JCasC and EOS

### DIFF
--- a/argocd-apps/external-secrets-app.yaml
+++ b/argocd-apps/external-secrets-app.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/tracking-id: jenkins-apps:argoproj.io/Application:argocd/external-secrets
+spec:
+  project: jenkins
+  source:
+    repoURL: https://charts.external-secrets.io
+    chart: external-secrets
+    targetRevision: "0.9.20"
+    helm:
+      values: |
+        installCRDs: true
+        webhook:
+          port: 9443
+        certController:
+          create: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-secrets-system
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd-apps/external-secrets-resources-app.yaml
+++ b/argocd-apps/external-secrets-resources-app.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/tracking-id: jenkins-apps:argoproj.io/Application:argocd/external-secrets-resources
+spec:
+  project: jenkins
+  source:
+    repoURL: https://github.com/lfit/jenkins-gitops
+    targetRevision: main
+    path: base/external-secrets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: jenkins-staging
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true

--- a/base/external-secrets/lf-jenkins-secret.yaml
+++ b/base/external-secrets/lf-jenkins-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: jenkins-lf-admin
+  namespace: jenkins-staging
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-store
+    kind: SecretStore
+  target:
+    name: jenkins-lf-admin
+    creationPolicy: Owner
+  data:
+  - secretKey: admin-username
+    remoteRef:
+      key: jenkins-lf-admin
+      property: username
+  - secretKey: admin-password
+    remoteRef:
+      key: jenkins-lf-admin
+      property: password

--- a/base/external-secrets/secret-store.yaml
+++ b/base/external-secrets/secret-store.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: onepassword-store
+  namespace: jenkins-staging
+spec:
+  provider:
+    onepassword:
+      connectHost: http://onepassword-connect.onepassword-connect.svc.cluster.local:8080
+      vaults:
+        jenkins: 1
+      auth:
+        secretRef:
+          connectToken:
+            name: onepassword-token
+            key: token

--- a/base/jenkins/jcasc_yamls/02-security.yaml
+++ b/base/jenkins/jcasc_yamls/02-security.yaml
@@ -6,7 +6,9 @@ jenkins:
       allowsSignup: false
       users:
         - id: "admin"
-          password: '${JCASC_JENKINSSECURITY_ADMINPASSWORD}'
+          password: '${JCASC_ADMIN_PASSWORD}'
+        - id: "lf-jenkins"
+          password: '${JCASC_LFJENKINS_ADMINPASSWORD}'
   authorizationStrategy:
     loggedInUsersCanDoAnything:
       allowAnonymousRead: false

--- a/base/jenkins/values.yaml
+++ b/base/jenkins/values.yaml
@@ -14,6 +14,9 @@ serviceAccount:
 # Pass all configuration to Jenkins subchart
 jenkins:
   controller:
+    # Admin users managed via JCasC security configuration
+    # See: base/jenkins/jcasc_yamls/02-security.yaml
+
     image:
       registry: "ghcr.io"
       repository: "lfit/jenkins"
@@ -68,8 +71,8 @@ jenkins:
               local:
                 allowsSignup: false
                 users:
-                  - id: "admin"
-                    password: '${JCASC_JENKINSSECURITY_ADMINPASSWORD}'
+                  - id: "lf-jenkins"
+                    password: '${JCASC_LFJENKINS_ADMINPASSWORD}'
             authorizationStrategy:
               loggedInUsersCanDoAnything:
                 allowAnonymousRead: false

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -86,6 +86,18 @@ jenkins:
       - name: JCASC_JENKINSGLOBALENVVARS_SILO
         value: "staging"
 
+      # Jenkins Security Configuration
+      - name: JCASC_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: jenkins-admin
+            key: admin-password
+      - name: JCASC_LFJENKINS_ADMINPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: jenkins-lf-admin
+            key: admin-password
+
       # Kubernetes Cloud Configuration
       - name: JCASC_KUBERNETES_URL
         value: "https://kubernetes.default.svc.cluster.local"


### PR DESCRIPTION
- Configured JCasC security with dual admin users:
  * admin user from K8s secret (jenkins-admin)
  * lf-jenkins user from 1Password via External Secrets
- Added environment variables for credential references:
  * JCASC_ADMIN_PASSWORD → jenkins-admin K8s secret
  * JCASC_LFJENKINS_ADMINPASSWORD → jenkins-lf-admin external secret
- Added External Secrets Operator integration with 1Password connector
- ESO ArgoCD apps created with auto-sync disabled for safe review and infrastructure setup

Validated with helm lint, kubeconform, and kubectl dry-run (no cluster deployment).

Next steps:
- Create onepassword-token secret with 1Password Connect API token
- Enable ESO ArgoCD auto-sync after token secret is deployed and verified