### PR TITLE
feat: enable ArgoCD auto-sync for External Secrets

### DIFF
--- a/argocd-apps/external-secrets-app.yaml
+++ b/argocd-apps/external-secrets-app.yaml
@@ -22,5 +22,8 @@ spec:
     server: https://kubernetes.default.svc
     namespace: external-secrets-system
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true

--- a/argocd-apps/external-secrets-resources-app.yaml
+++ b/argocd-apps/external-secrets-resources-app.yaml
@@ -15,5 +15,8 @@ spec:
     server: https://kubernetes.default.svc
     namespace: jenkins-staging
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
Adds automated syncPolicy to External Secrets Operator and resources applications to deploy the 1Password integration needed for Jenkins admin authentication.