### PR TITLE
feat: add cluster permissions for ESO

### DIFF
--- a/argocd-apps/jenkins-project.yaml
+++ b/argocd-apps/jenkins-project.yaml
@@ -23,6 +23,14 @@ spec:
   clusterResourceWhitelist:
   - group: ''
     kind: Namespace
+  - group: 'apiextensions.k8s.io'
+    kind: CustomResourceDefinition
+  - group: 'rbac.authorization.k8s.io'
+    kind: ClusterRole
+  - group: 'rbac.authorization.k8s.io'
+    kind: ClusterRoleBinding
+  - group: 'admissionregistration.k8s.io'
+    kind: ValidatingWebhookConfiguration
   namespaceResourceWhitelist:
   - group: '*'
     kind: '*'


### PR DESCRIPTION
Add cluster-scoped resource permissions to jenkins ArgoCD project to enable External Secrets Operator deployment for Jenkins admin authentication.

Adds permissions for:
- CustomResourceDefinition (apiextensions.k8s.io)
- ClusterRole (rbac.authorization.k8s.io)
- ClusterRoleBinding (rbac.authorization.k8s.io)
- ValidatingWebhookConfiguration (admissionregistration.k8s.io)

Validation tests run:
- helm lint base/jenkins
- helm template + kubectl dry-run (dev/staging/prod)
- kubeconform schema validation (all environments)
- kubectl server dry-run for External Secrets manifests
- yamllint argocd-apps/jenkins-project.yaml