### PR TITLE
feat:  sidecar discovery label to JCasC ConfigMap

### DIFF
--- a/base/jenkins/templates/jcasc-configmap.yaml
+++ b/base/jenkins/templates/jcasc-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "jenkins.labels" . | nindent 4 }}
     app.kubernetes.io/component: jcasc
+    {{ template "jenkins.fullname" . }}-jenkins-config: "true"
 data:
 {{- $files := .Files.Glob "jcasc_yamls/*.yaml" }}
 {{- range $path, $_ := $files }}


### PR DESCRIPTION
The external JCasC refactor (commit 4e08775) moved configurations from inline configScripts to external files but missed the required sidecar discovery label. This caused the container to ignore external JCasC files, preventing credentials and other configurations from loading.