### PR TITLE
fix: dual source conflicts

### DIFF
--- a/base/jenkins/values.yaml
+++ b/base/jenkins/values.yaml
@@ -30,6 +30,11 @@ jenkins:
     # JCasC configuration now managed via configScripts in environment values.yaml files
     # Environment-specific JCasC settings in: staging/values.yaml and production/values.yaml
 
+    # Jenkins Configuration as Code - disable chart defaults globally
+    # All environments use explicit configScripts for GitOps compliance
+    JCasC:
+      defaultConfig: false
+
     # Container image configuration for Jenkins controller
     # Base layer provides defaults, environment layers control specific versions
     # Image versioning and pull policy controlled in: staging/values.yaml and production/values.yaml

--- a/production/values.yaml
+++ b/production/values.yaml
@@ -32,6 +32,11 @@ jenkins:
     # Prevents plugin version conflicts in production environment
     installPlugins: false
 
+    # Jenkins Configuration as Code
+    # Complete JCasC configuration for production environment
+    JCasC:
+      defaultConfig: false
+
     # Resource allocation for production environment
     # Higher resource limits appropriate for production workloads
     resources:

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -34,7 +34,7 @@ jenkins:
 
     # Jenkins Configuration as Code
     JCasC:
-      defaultConfig: true
+      defaultConfig: false
       configScripts:
         # OFFICIAL MULTIPLE ROOT KEYS PATTERN
         # Organizes configurations by root key type to eliminate merge conflicts


### PR DESCRIPTION
Resolves dual-source JCasC configuration conflicts

Problem: Jenkins Helm chart defaultConfig: true conflicted with explicit configScripts, causing ConfiguratorConflictException during initialization.

Root Cause: JCasC plugin recommends defaultConfig: true but GitOps requires explicit configuration control.

Solution: Set defaultConfig: false globally to disable chart-provided JCasC defaults. All environments now use explicit configScripts for complete configuration control.

GitOps Compliance: Follows Argo CD GitOps principles requiring declarative, versioned configuration without implicit defaults or hidden state.

Validation: Helm template + kubectl dry-run successful for staging environment.