### PR TITLE
fix: credential syntax error

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -143,19 +143,19 @@ jenkins:
             system:
               domainCredentials:
                 - credentials:
-                    # 1Password Service Account Integration
-                    - onePasswordCredentials:
-                        id: "onepassword-integration"
-                        description: "1Password service account for build secret access"
-                        serviceAccountToken:
-                          secretName: "onepassword-sa-token"
-                          key: "token"
+                  # 1Password Service Account Integration
+                  - onePasswordCredentials:
+                      id: "onepassword-integration"
+                      description: "1Password service account for build secret access"
+                      serviceAccountToken:
+                        secretName: "onepassword-sa-token"
+                        key: "token"
 
-                    # GitHub Service Account Token for CI/CD Operations
-                    - string:
-                        id: "${GITHUB_CREDENTIALS_ID}"
-                        description: "GitHub opensearch-jenkins service account token"
-                        secret: "op://Employee/opensearch-jenkins-github-token/password"
+                  # GitHub Service Account Token for CI/CD Operations
+                  - string:
+                      id: "${GITHUB_CREDENTIALS_ID}"
+                      description: "GitHub opensearch-jenkins service account token"
+                      secret: "op://Employee/opensearch-jenkins-github-token/password"
 
         unclassified-config: |
           unclassified:


### PR DESCRIPTION
Fixed credentials list items to use proper YAML syntax with dash prefix instead of nested structure under domainCredentials.

Validation completed:
- YAML syntax check: passed
- Helm template generation: successful
- Kubernetes dry-run: all resources validated
- Live deployment test: Jenkins restarted successfully