### PR TITLE
fix: increase startup probe

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -32,6 +32,13 @@ jenkins:
     # Prevents plugin version conflicts in staging environment
     installPlugins: false
 
+    # Kubernetes health probe configuration for staging environment
+    # Increase startup probe timeout to accommodate Jenkins initialization with plugins
+    # Default: 12 failures × 10s = 120s, Updated: 18 failures × 10s = 180s (3 minutes)
+    probes:
+      startupProbe:
+        failureThreshold: 18
+
     # Jenkins Configuration as Code
     JCasC:
       defaultConfig: false


### PR DESCRIPTION
Increase startup probe to 180 seconds for initialization

Validation performed:
- YAML syntax validation (yamllint)
- Helm template rendering verification
- Helm lint validation
- kubectl dry-run (client & server-side)
- Probe configuration confirmed: 18 × 10s = 180s