### PR TITLE
feat: add IAM role for EC2

### DIFF
--- a/production/values.yaml
+++ b/production/values.yaml
@@ -18,6 +18,11 @@
 # Jenkins subchart configuration overrides
 # Inherits base configuration from: base/jenkins/values.yaml
 jenkins:
+  # Service account configuration for AWS IAM role assumption
+  serviceAccount:
+    annotations:
+      "eks.amazonaws.com/role-arn": "arn:aws:iam::156041419073:role/jenkins-prod-irsa"
+
   controller:
     # Container image configuration for production environment
     # Uses specific commit SHA for production stability

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -18,6 +18,11 @@
 # Jenkins subchart configuration overrides
 # Inherits base configuration from: base/jenkins/values.yaml
 jenkins:
+  # Service account configuration for AWS IAM role assumption
+  serviceAccount:
+    annotations:
+      "eks.amazonaws.com/role-arn": "arn:aws:iam::156041419073:role/jenkins-staging-irsa"
+
   controller:
     # Container image configuration for staging environment
     # Uses specific commit SHA for staging validation


### PR DESCRIPTION
Enables Jenkins EC2 authentication by adding IRSA role annotations to service accounts for both staging and production environments.

Validation:
- Helm template rendering