### PR TITLE
fix: Update GitHub credentials

### DIFF
--- a/production/values.yaml
+++ b/production/values.yaml
@@ -78,6 +78,8 @@ jenkins:
                       value: '${JCASC_SILO}'
                     - key: "JENKINS_URL"
                       value: '${JCASC_JENKINS_URL}'
+                    - key: "JCASC_GITHUB_CREDENTIALS_ID"
+                      value: "github-token"
                     - key: "GITHUB_CREDENTIALS_ID"
                       value: '${JCASC_GITHUB_CREDENTIALS_ID:-github-token}'
                     - key: "SAML_METADATA_URL"

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -85,6 +85,8 @@ jenkins:
                       value: '${JCASC_SILO}'
                     - key: "JENKINS_URL"
                       value: '${JCASC_JENKINS_URL}'
+                    - key: "JCASC_GITHUB_CREDENTIALS_ID"
+                      value: "github-token"
                     - key: "GITHUB_CREDENTIALS_ID"
                       value: '${JCASC_GITHUB_CREDENTIALS_ID:-github-token}'
                     - key: "SAML_METADATA_URL"


### PR DESCRIPTION
Resolves GitHub plugin credential resolution by adding JCASC_GITHUB_CREDENTIALS_ID environment variable

Validation:
 - YAML syntax passed
 - Helm rendering passed
 - JCasC pattern verified