### PR TITLE
fix: remove GITHUB_CREDENTIALS_ID shell expansion

### DIFF
--- a/production/values.yaml
+++ b/production/values.yaml
@@ -80,8 +80,6 @@ jenkins:
                       value: '${JCASC_JENKINS_URL}'
                     - key: "JCASC_GITHUB_CREDENTIALS_ID"
                       value: "github-token"
-                    - key: "GITHUB_CREDENTIALS_ID"
-                      value: '${JCASC_GITHUB_CREDENTIALS_ID:-github-token}'
                     - key: "SAML_METADATA_URL"
                       value: '${SAML_METADATA_URL}'
                     - key: "SAML_LOGOUT_URL"

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -87,8 +87,6 @@ jenkins:
                       value: '${JCASC_JENKINS_URL}'
                     - key: "JCASC_GITHUB_CREDENTIALS_ID"
                       value: "github-token"
-                    - key: "GITHUB_CREDENTIALS_ID"
-                      value: '${JCASC_GITHUB_CREDENTIALS_ID:-github-token}'
                     - key: "SAML_METADATA_URL"
                       value: '${SAML_METADATA_URL}'
                     - key: "SAML_LOGOUT_URL"


### PR DESCRIPTION
Fixed Helm conflict caused by shell expansion

Validation:
 - Helm template
 - Variable resolution