### PR TITLE
fix: Add GITHUB_CREDENTIALS_ID env var for JCasC

### DIFF
--- a/production/values.yaml
+++ b/production/values.yaml
@@ -268,6 +268,8 @@ jenkins:
         value: ""
       - name: JCASC_DOCKER_REGISTRY
         value: ""
+      - name: GITHUB_CREDENTIALS_ID
+        value: "github-token"
       - name: JCASC_S3_BUCKET
         value: ""
       - name: JCASC_CDN_URL

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -268,6 +268,8 @@ jenkins:
         value: ""
       - name: JCASC_DOCKER_REGISTRY
         value: ""
+      - name: GITHUB_CREDENTIALS_ID
+        value: "github-token"
       - name: JCASC_S3_BUCKET
         value: ""
       - name: JCASC_CDN_URL


### PR DESCRIPTION
Fixes GitHub plugin authentication issues by adding the missing environment variable that Jenkins needs to connect to GitHub.