### PR TITLE
fix: MVN tool configuration

### DIFF
--- a/base/jenkins/jcasc_yamls/01-tools.yaml
+++ b/base/jenkins/jcasc_yamls/01-tools.yaml
@@ -16,6 +16,11 @@ tool:
       - name: "jdk-17"
         home: "/opt/java/openjdk"
 
+  # Maven Global Configuration
+  mavenGlobalConfig:
+    globalSettingsProvider: "standard"
+    settingsProvider: "standard"
+
   # Git
   git:
     installations:


### PR DESCRIPTION
Change: Add Maven Global Configuration to JCasC tools configuration using standard settings providers.

Validation:

YAML syntax validated successfully
Helm dry run template generation completed without errors Configuration matches official Jenkins CasC documentation patterns Maven Global Config now present in rendered tool-config.yaml ConfigMap Maintains consistency with existing JDK and Git tool configurations