### PR TITLE
fix: SSH vault

### DIFF
--- a/production/values.yaml
+++ b/production/values.yaml
@@ -168,7 +168,7 @@ jenkins:
                       description: "SSH key for OpenSearch EC2 agents"
                       privateKeySource:
                         directEntry:
-                          privateKey: "${op://Employee/opensearch-jenkins-ec2-key/private key}"
+                          privateKey: "${op://OpenSearch Project/opensearch-jenkins-ec2-key/private key}"
 
         unclassified-config: |
           unclassified:

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -175,7 +175,7 @@ jenkins:
                       description: "SSH key for OpenSearch EC2 agents"
                       privateKeySource:
                         directEntry:
-                          privateKey: "${op://Employee/opensearch-jenkins-ec2-key/private key}"
+                          privateKey: "${op://OpenSearch Project/opensearch-jenkins-ec2-key/private key}"
 
         unclassified-config: |
           unclassified:


### PR DESCRIPTION
Updated SSH key vault from Employee to OpenSearch Project Aligns with GitHub token vault configuration pattern Validation: yamllint, helm template, kubectl dry-run passed Regression: confirmed only SSH vault references changed Environments: staging and production updated