### PR TITLE
fix: 1Password CLI permissions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -72,6 +72,9 @@ RUN mkdir -p /var/jenkins && chown -R jenkins:jenkins /var/jenkins
 # Switch back to jenkins user
 USER jenkins
 
+# Create 1Password CLI config directory with correct permissions
+RUN mkdir -m 700 -p /var/jenkins_home/.config/op
+
 # Install Jenkins plugins
 RUN jenkins-plugin-cli --verbose --plugin-file /usr/share/jenkins/ref/plugins.txt
 


### PR DESCRIPTION
Add mkdir and chmod for /var/jenkins_home/.config/op in Dockerfile

Validation:
 - Tested 1Password CLI authentication works with token
2. EC2 SSH key secret reference resolves correctly