### PR TITLE
Add EC2 SSH key via ESO

### DIFF
--- a/base/jenkins/templates/ec2-key-secret.yaml
+++ b/base/jenkins/templates/ec2-key-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opensearch-jenkins-ec2-key
+  namespace: {{ template "jenkins.namespace" . }}
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: onepassword-releng
+  target:
+    creationPolicy: Owner
+  data:
+    - secretKey: private-key
+      remoteRef:
+        key: "opensearch-jenkins-ec2-key/private key"


### PR DESCRIPTION
Since the 1Password plugin can only manage job-level secrets and cannot do system credentials, fetch the Opensearch SSH key via the cluster's ExternalSecrets operator to load in from a Kubernetes secret.
