### PR TITLE
feat: migrate credentials from 1Password to ESO

### DIFF
--- a/base/jenkins/jcasc_yamls/04-credentials.yaml
+++ b/base/jenkins/jcasc_yamls/04-credentials.yaml
@@ -36,6 +36,5 @@ credentials:
           - string:
               id: "${GITHUB_CREDENTIALS_ID:-github-token}"
               description: "GitHub opensearch-jenkins service account token (opensearch-jenkins-github-token)"
-              # 1Password vault reference for GitHub token
-              # Vault: Employee, Item: opensearch-jenkins-github-token, Field: password
-              secret: "op://Employee/opensearch-jenkins-github-token/password"
+              # ESO-managed credential from 1Password via environment variable
+              secret: "${OPENSEARCH_GITHUB_TOKEN}"

--- a/base/jenkins/templates/github-token-secret.yaml
+++ b/base/jenkins/templates/github-token-secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opensearch-jenkins-github-token
+  namespace: {{ template "jenkins.namespace" . }}
+spec:
+  secretStoreRef:
+    kind: SecretStore
+    name: onepassword-releng
+  target:
+    creationPolicy: Owner
+  data:
+    - secretKey: password
+      remoteRef:
+        key: "opensearch-jenkins-github-token/password"

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -220,7 +220,7 @@ jenkins:
                   - string:
                       id: "${GITHUB_CREDENTIALS_ID}"
                       description: "GitHub opensearch-jenkins service account token"
-                      secret: "op://Release Engineering/opensearch-jenkins-github-token/password"
+                      secret: "${OPENSEARCH_GITHUB_TOKEN}"
 
                   # SSH Private Key for OpenSearch EC2 Agents
                   - basicSSHUserPrivateKey:
@@ -230,7 +230,7 @@ jenkins:
                       description: "SSH key for OpenSearch EC2 agents"
                       privateKeySource:
                         directEntry:
-                          privateKey: "op://Release Engineering/opensearch-jenkins-ec2-key/private key"
+                          privateKey: "${OPENSEARCH_EC2_PRIVATE_KEY}"
 
         unclassified-config: |
           unclassified:
@@ -368,6 +368,20 @@ jenkins:
         secretKeyRef:
           name: onepassword-sa-token
           key: token
+
+    # EC2 SSH Private Key (ESO-managed from 1Password)
+    - name: OPENSEARCH_EC2_PRIVATE_KEY
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-jenkins-ec2-key
+          key: private-key
+
+    # GitHub Token (ESO-managed from 1Password)
+    - name: OPENSEARCH_GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: opensearch-jenkins-github-token
+          key: password
 
     # Kubernetes Cloud Configuration (07-cloud-agents.yaml integration)
     - name: JCASC_KUBERNETES_URL


### PR DESCRIPTION
The 1Password plugin cannot resolve op:// references so we're replacing with ESO managed environment variables