### PR TITLE
fix: update AMI to latest AL2023 in us-west-2

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -167,7 +167,7 @@ jenkins:
                   useInstanceProfileForCredentials: false
                   sshKeysCredentialsId: "opensearch-ec2-key"
                   templates:
-                    - ami: "ami-06a974f9b8a97ecf2"
+                    - ami: "ami-0095b2d932ba790f3"
                       amiType:
                         unixData:
                           sshPort: "22"
@@ -184,7 +184,9 @@ jenkins:
                       initScript: >
                         sudo dnf clean all && sudo rm -rf /var/cache/dnf && sudo dnf repolist &&
                         sudo dnf update --releasever=latest --skip-broken --exclude=openssh*
-                        --exclude=docker* --exclude=gh* --exclude=openssl* -y && docker ps
+                        --exclude=docker* --exclude=gh* --exclude=openssl* -y &&
+                        sudo dnf install -y java-17-openjdk-devel git &&
+                        docker ps
                       labelString: "jenkins-agent-staging-test"
                       launchTimeoutStr: "300"
                       maxTotalUses: 10


### PR DESCRIPTION
- Update AMI to AL2023 ECS for us-west-2)
- Add JDK 17 installation to initScript for Jenkins agent

Validation:
- AMI verified available in us-west-2 region
- YAML syntax validated