### PR TITLE
fix: remove security group from JCasC management

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -200,7 +200,7 @@ jenkins:
                       numExecutors: "1"
                       remoteAdmin: "ec2-user"
                       remoteFS: "/home/ec2-user"
-                      securityGroups: "jenkins-node-20250827030329319600000004"
+                      # securityGroups: "jenkins-node-20250827030329319600000004" # Removed due to EC2 plugin bug - configure manually in UI
                       stopOnTerminate: false
                       t2Unlimited: false
                       tenancy: Default


### PR DESCRIPTION
Removing the security group from the JCasC management as a workaround for an issue of the plugin not passing the value causing errors when trying to start the agent