### PR TITLE
fix: use Datree catalog for ArgoCD schemas

### DIFF
--- a/.github/workflows/validate-argocd-schema.yml
+++ b/.github/workflows/validate-argocd-schema.yml
@@ -26,8 +26,13 @@ concurrency:
 jobs:
   validate-schema:
     name: Validate ArgoCD Manifest Schemas
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
+
+    env:
+      KUBECONFORM_VERSION: v0.7.0
+      KUBECONFORM_SHA256: c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3
+      K8S_SCHEMA_VERSION: "1.33.0"
 
     defaults:
       run:
@@ -40,11 +45,12 @@ jobs:
       - name: Download kubeconform
         run: |
           set -euo pipefail
-          curl -sSfLo /tmp/kubeconform.tar.gz \
-            https://github.com/yannh/kubeconform/releases/download/v0.7.0/kubeconform-linux-amd64.tar.gz
-          echo "c31518ddd122663b3f3aa874cfe8178cb0988de944f29c74a0b9260920d115d3  /tmp/kubeconform.tar.gz" | sha256sum -c
+          curl -sSfL --retry 3 --retry-delay 2 -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz
+          echo "${KUBECONFORM_SHA256}  /tmp/kubeconform.tar.gz" | sha256sum -c
           tar -xzf /tmp/kubeconform.tar.gz -C /tmp
           chmod +x /tmp/kubeconform
+          /tmp/kubeconform -version
 
       - name: Validate ArgoCD manifests
         run: |
@@ -53,7 +59,8 @@ jobs:
             -strict \
             -summary \
             -output text \
-            -kubernetes-version 1.33.0 \
+            -kubernetes-version ${K8S_SCHEMA_VERSION} \
             -schema-location default \
-            -schema-location 'https://raw.githubusercontent.com/argoproj/argo-cd/v2.13.0/manifests/crds/{{.ResourceKind | lower}}-crd.yaml' \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             argocd-apps/
+          echo "✅ kubeconform validation passed for argocd-apps/ (k8s=${K8S_SCHEMA_VERSION})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
- Use Datree CRDs-catalog for ArgoCD schema validation
- Add env vars for version management
- Add GitHub step summary